### PR TITLE
feat(audit): Implement QueryAuditor audit feature with recusive parsing.

### DIFF
--- a/src/main/scala/com/silectis/sql/audit/QueryAuditor.scala
+++ b/src/main/scala/com/silectis/sql/audit/QueryAuditor.scala
@@ -1,21 +1,106 @@
 package com.silectis.sql.audit
 
+import com.silectis.sql.ColumnAlias
+import com.silectis.sql.ColumnReference
+import com.silectis.sql.ColumnExpression
+import com.silectis.sql.SqlFunction
+import com.silectis.sql.Subquery
+import com.silectis.sql.TableAlias
+import com.silectis.sql.TableExpression
+import com.silectis.sql.TableReference
 import com.silectis.sql.parse.SqlParser
 import com.typesafe.scalalogging.LazyLogging
 
 import scala.util.Try
+import com.silectis.sql.QueryColumn
 
 class QueryAuditor extends LazyLogging {
   private val parser = new SqlParser
 
+  private def parseTable(
+      from: Option[TableExpression],
+      columnsBuffer: scala.collection.mutable.ArrayBuffer[String]
+  ): Option[TableReference] = {
+    from match {
+      case Some(ref: TableReference) => Some(ref)
+      case Some(alias: TableAlias)   => Some(alias.table)
+      case Some(subquery: Subquery) =>
+        val innerColumnsBuffer = scala.collection.mutable.ArrayBuffer[String]()
+        parseColumns(
+          subquery.query.columns,
+          subquery.query.from,
+          innerColumnsBuffer
+        )
+        parseColumns(subquery.query.columns, Some(subquery), columnsBuffer)
+        parseTable(subquery.query.from, columnsBuffer)
+      case None => None
+    }
+  }
+
+  private def parseColumns(
+      columns: Seq[QueryColumn],
+      from: Option[TableExpression],
+      columnsBuffer: scala.collection.mutable.ArrayBuffer[String]
+  ): Unit = {
+    from match {
+      case Some(_: TableReference) =>
+        columns.foreach {
+          case ColumnReference(columnName) => columnsBuffer += columnName
+          case ColumnAlias(expr, _) =>
+            extractColumnName(expr).foreach(columnsBuffer += _)
+          case _ =>
+        }
+
+      case Some(alias: TableAlias) =>
+        parseColumns(columns, Some(alias.table), columnsBuffer)
+
+      case Some(subquery: Subquery) =>
+        val innerColumnsBuffer = scala.collection.mutable.ArrayBuffer[String]()
+        parseColumns(
+          subquery.query.columns,
+          subquery.query.from,
+          innerColumnsBuffer
+        )
+
+        columns.foreach {
+          case ColumnAlias(expr, _) =>
+            extractColumnName(expr)
+              .filter(innerColumnsBuffer.contains)
+              .foreach(columnsBuffer += _)
+          case ColumnReference(columnName)
+              if innerColumnsBuffer.contains(columnName) =>
+            columnsBuffer += columnName
+          case _ =>
+        }
+
+      case None =>
+    }
+  }
+
+  private def extractColumnName(expr: ColumnExpression): Option[String] = {
+    expr match {
+      case ColumnReference(columnName) => Some(columnName)
+      case _                           => None
+    }
+  }
+
+  /**
+    * Audit a SQL query.
+    *
+    * @param sql The sql string to audit.
+    * @return A QueryAuditResult with the schema, table, and columns (assuming any exist).
+    */
   def audit(sql: String): Try[QueryAuditResult] = {
     Try(parser.parse(sql))
       .map { query =>
         logger.debug(s"""Parsed query "$sql" as $query""")
 
-        // TODO determine which columns are accessed by the query
+        val columnsBuffer = scala.collection.mutable.ArrayBuffer[String]()
 
-        throw new NotImplementedError
+        var table = parseTable(query.from, columnsBuffer)
+        parseColumns(query.columns, query.from, columnsBuffer)
+
+        new QueryAuditResult(table, columnsBuffer.distinct.toSeq)
       }
   }
 }

--- a/src/test/scala/com/silectis/sql/audit/QueryAuditorSpec.scala
+++ b/src/test/scala/com/silectis/sql/audit/QueryAuditorSpec.scala
@@ -1,10 +1,13 @@
 package com.silectis.sql.audit
 
 import com.silectis.sql.SqlException
+import com.silectis.sql.TableExpression
+import com.silectis.sql.TableReference
 import com.silectis.test.UnitSpec
+import scala.util.Success
 
-/**
-  * @author jlouns
+/** @author
+  *   jlouns
   */
 class QueryAuditorSpec extends UnitSpec {
   val auditor = new QueryAuditor
@@ -12,5 +15,80 @@ class QueryAuditorSpec extends UnitSpec {
   it should "return failure for an invalid SQL query" in {
     a[SqlException] should be thrownBy
       auditor.audit("not valid sql").get
+  }
+
+  it should "return the correct query from a table" in {
+    val parsed = auditor.audit("select col1, col2 from table1")
+    parsed shouldBe Success(
+      QueryAuditResult(
+        Some(TableReference(None, "table1")),
+        List("col1", "col2")
+      )
+    )
+  }
+
+  it should "return the correct query from a table with a schema" in {
+    val parsed = auditor.audit("SELECT col1 FROM schema1.table1")
+    parsed shouldBe Success(
+      QueryAuditResult(
+        Some(TableReference(Some("schema1"), "table1")),
+        List("col1")
+      )
+    )
+  }
+
+  it should "return the correct query with no table and no columns" in {
+    val parsed = auditor.audit("select 1 as one, 'two'")
+    parsed shouldBe Success(
+      QueryAuditResult(
+        None,
+        List()
+      )
+    )
+  }
+
+  it should "return the correct query with a column expression non-nested subquery" in {
+    val parsed = auditor.audit("SELECT 1, upper('test') AS name FROM table1")
+    parsed shouldBe Success(
+      QueryAuditResult(Some(TableReference(None, "table1")), List())
+    )
+  }
+
+  it should "return the correct query with a subquery and aliases" in {
+    val parsed = auditor.audit("""
+    select a, b, x, y from (
+      select
+        col1 as a,
+        2 as b,
+        x,
+        upper('test') as y
+      from table2
+    ) as s
+    """)
+    parsed shouldBe Success(
+      QueryAuditResult(
+        Some(TableReference(None, "table2")),
+        List("col1", "x")
+      )
+    )
+  }
+
+  it should "return the correct query with a nested subquery" in {
+    val parsed = auditor.audit("""
+    SELECT x, y FROM (
+      SELECT a AS x, b AS y FROM (
+        SELECT
+          col1 AS a,
+          col2 AS b
+        FROM table3
+      ) AS inner
+    ) AS outer
+    """)
+    parsed shouldBe Success(
+      QueryAuditResult(
+        Some(TableReference(None, "table3")),
+        List("col1", "col2")
+      )
+    )
   }
 }


### PR DESCRIPTION
Add logic to parse columns and tables recusively. Includes the handling of subqueries, column aliases, and table references.

Add unit tests covering basic queries, subqueries, nested subqueries, and edge cases such as:
    - queries without tables
    - queries with non-column expressions